### PR TITLE
URL redirect implemented

### DIFF
--- a/FASTN.ftd
+++ b/FASTN.ftd
@@ -24,3 +24,4 @@ favicon: /-/fastn-community.github.io/aiglesoft-inc/favicon.ico
 # Blog: /blog/
 
 -- fastn.redirects:
+/launching-color-support/: /color-support/


### PR DESCRIPTION
Based on our Google Analytics data & recommendations from our SEO team, current URL ( /`launching-color-support`/) now redirects to (/`color-support`/)